### PR TITLE
Fix pki_contract_name argument in web3 deployment

### DIFF
--- a/zkay/transaction/blockchain/web3py.py
+++ b/zkay/transaction/blockchain/web3py.py
@@ -170,7 +170,7 @@ class Web3Blockchain(ZkayBlockchainInterface):
         with cfg.library_compilation_environment():
             with tempfile.TemporaryDirectory() as tmpdir:
                 for crypto_params in cfg.all_crypto_params():
-                    contract_name = cfg.get_pki_contract_name(crypto_params.crypto_name)
+                    contract_name = cfg.get_pki_contract_name(crypto_params)
                     pki_sol = save_to_file(tmpdir, f'{contract_name}.sol', library_contracts.get_pki_contract(crypto_params))
                     self._pki_contract = self._verify_contract_integrity(cfg.blockchain_pki_address, pki_sol, contract_name=contract_name)
 


### PR DESCRIPTION
Type: bug-fix

This pull requests fixes an invalid argument type bug.
The UserConfig.get_pki_contract_name method requires an instance of CryptoParams class as argument instead of the derived string property CryptoParams.crypto_name.