### PR TITLE
Fix invalid relative classpath in proof generation

### DIFF
--- a/zkay/transaction/interface.py
+++ b/zkay/transaction/interface.py
@@ -683,7 +683,7 @@ class ZkayProverInterface(metaclass=ABCMeta):
 
         with time_measure(f'generate_proof', True):
             verify_dir = cfg.get_circuit_output_dir_name(cfg.get_verification_contract_name(contract, function))
-            return self._generate_proof(os.path.join(project_dir, verify_dir), priv_values, in_vals, out_vals)
+            return self._generate_proof(os.path.abspath(os.path.join(project_dir, verify_dir)), priv_values, in_vals, out_vals)
 
     @abstractmethod
     def _generate_proof(self, verifier_dir: str, priv_values: List[int], in_vals: List[int], out_vals: List[int]) -> List[int]:


### PR DESCRIPTION
Type: bug-fix

Convert a relative verifier_directory path, that may lead to a ClassNotFound java exception in jsnark, into a absolute path.

Fixes the following error:
zkay.transaction.interface.ProofGenerationError: ('Non-zero exit status 1 for command:\n/tmp/tmp47ar4m10: $ java -Xms4096m -Xmx16384m -cp /mnt/.../zkay/zkay/jsnark_interface/JsnarkCircuitBuilder.jar:./contract_compiled/zk__Verify_Contract_constructor_out ZkayCircuit prove [...]\n\n\nError: Could not find or load main class ZkayCircuit\nCaused by: java.lang.ClassNotFoundException: ZkayCircuit',)